### PR TITLE
Keep paideia MCP bootable when plugin vars are not expanded

### DIFF
--- a/plugins/paideia/.mcp.json
+++ b/plugins/paideia/.mcp.json
@@ -3,12 +3,9 @@
     "paideia-mcp": {
       "command": "python3",
       "args": [
-        "-m",
-        "paideia_mcp.server"
+        "-c",
+        "exec(\"import os\\nimport pathlib\\nimport sys\\n\\nroots = []\\nenv = os.environ.get(\\\"CODEX_PLUGIN_ROOT\\\")\\nif env:\\n    roots.append(pathlib.Path(env))\\n\\nhome = pathlib.Path.home()\\nfor pattern in (\\n    \\\".codex/plugins/cache/*/paideia/*\\\",\\n    \\\".codex/.tmp/marketplaces/*/plugins/paideia\\\",\\n):\\n    roots.extend(home.glob(pattern))\\n\\nfor root in roots:\\n    mcp = root / \\\"paideia-mcp\\\"\\n    if (mcp / \\\"paideia_mcp\\\" / \\\"server.py\\\").exists():\\n        sys.path.insert(0, str(mcp))\\n        break\\nelse:\\n    raise SystemExit(\\n        \\\"paideia-mcp: cannot locate paideia_mcp package; \\\"\\n        f\\\"CODEX_PLUGIN_ROOT={env!r}\\\"\\n    )\\n\\nfrom paideia_mcp.server import main\\n\\nmain()\")"
       ],
-      "env": {
-        "PYTHONPATH": "${CODEX_PLUGIN_ROOT}/paideia-mcp"
-      },
       "startup_timeout_sec": 15,
       "tool_timeout_sec": 1800,
       "supports_parallel_tool_calls": true


### PR DESCRIPTION
## Summary
- replace the MCP env-based PYTHONPATH launcher with a Python bootstrap command
- use CODEX_PLUGIN_ROOT when Codex provides it
- fall back to the local Codex plugin cache / marketplace checkout when the variable is not expanded on Windows

## Why
On this Windows Codex App install, the MCP config passed the literal value `${CODEX_PLUGIN_ROOT}/paideia-mcp` into PYTHONPATH. Python then failed before initialize with `ModuleNotFoundError: No module named 'paideia_mcp'`.

## Verification
- Direct MCP ClientSession initialize + list_tools succeeded:
  - `INIT paideia-mcp 2025-11-25`
  - `TOOLS ingest_pdfs,grade_pdf,build_course_index,course_phase`
- `codex exec` invoked `paideia-mcp.course_phase` successfully:
  - `{"phase":"setup","days_until_exam":null,"top_miss_pattern":null,"course_name":null}`

## Notes
The local absolute path fix was intentionally rejected because it is not portable across users or plugin versions.
